### PR TITLE
Release 0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Make all iterators reversible (#62).
 * Add `key_of()` method (#61)
 * Add `compact()` method (#60)
+* Add support for serde (#85)
 
 # 0.4.2 (January 11, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.4.3 (February 6, 2021)
+
+* Add no_std support for Rust 1.36 and above (#71).
+* Add `get2_mut` and `get2_unchecked_mut` methods (#65).
+* Make `shrink_to_fit()` remove trailing vacant entries (#62).
+* Implement `FromIterator<(usize, T)>` (#62).
+* Implement `IntoIterator<Item = (usize, T)>` (#62).
+* Provide `size_hint()` of the iterators (#62).
+* Make all iterators reversible (#62).
+* Add `key_of()` method (#61)
+* Add `compact()` method (#60)
+
 # 0.4.2 (January 11, 2019)
 
 * Add `Slab::drain` (#56).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,16 @@ name = "slab"
 #   - Cargo.toml
 #   - README.md
 # - Create git tag
-version = "0.4.2"
+version = "0.4.3"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Pre-allocated storage for a uniform data type"
-documentation = "https://docs.rs/slab/0.4.2/slab/"
-homepage = "https://github.com/carllerche/slab"
-repository = "https://github.com/carllerche/slab"
+documentation = "https://docs.rs/slab/0.4.3/slab/"
+homepage = "https://github.com/tokio-rs/slab"
+repository = "https://github.com/tokio-rs/slab"
 readme = "README.md"
 keywords = ["slab", "allocator", "no_std"]
-categories = ["memory-management", "data-structures", "no_std"]
+categories = ["memory-management", "data-structures", "no-std"]
 
 [features]
 std = []

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pre-allocated storage for a uniform data type.
 [ci-badge]: https://img.shields.io/github/workflow/status/tokio-rs/slab/CI/master
 [ci-url]: https://github.com/tokio-rs/slab/actions
 
-[Documentation](https://docs.rs/slab/0.4.2/slab/)
+[Documentation](https://docs.rs/slab/0.4.3/slab/)
 
 ## Usage
 
@@ -18,7 +18,7 @@ To use `slab`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-slab = "0.4.2"
+slab = "0.4.3"
 ```
 
 Next, add this to your crate:


### PR DESCRIPTION
It's been over two years since the previous release. There is a lot of improvements in the master branch, and it would be nice to release them. Also, IIUC there is no breaking change that needs a major version bump.

Changes:

* Add no_std support for Rust 1.36 and above (#71).
* Add `get2_mut` and `get2_unchecked_mut` methods (#65).
* Make `shrink_to_fit()` remove trailing vacant entries (#62).
* Implement `FromIterator<(usize, T)>` (#62).
* Implement `IntoIterator<Item = (usize, T)>` (#62).
* Provide `size_hint()` of the iterators (#62).
* Make all iterators reversible (#62).
* Add `key_of()` method (#61)
* Add `compact()` method (#60)
* Add support for serde (#85)

