### PR TITLE
Fix non_fmt_panic warning

### DIFF
--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -592,16 +592,14 @@ fn compact_handles_closure_panic() {
         slab.compact(|&mut v, from, to| {
             assert!(from > to);
             assert_eq!(from, v);
-            // TODO: once Rust 1.51 become stable, use `std::panic::panic_any` instead.
-            #[allow(unknown_lints, non_fmt_panic)]
             if v == 7 {
-                panic!(());
+                panic!("test");
             }
             true
         })
     }));
     match result {
-        Err(ref payload) if payload.is::<()>() => {}
+        Err(ref payload) if payload.downcast_ref() == Some(&"test") => {}
         Err(bug) => resume_unwind(bug),
         Ok(()) => unreachable!(),
     }


### PR DESCRIPTION
Uses the way mentioned in [this comment](https://github.com/tokio-rs/slab/pull/80#issuecomment-774519728).