### PR TITLE
Add support for serde

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
-      - run: cargo build
-      - run: cargo test
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+      - run: cargo hack build --feature-powerset --optional-deps
+      - run: cargo test --all-features
 
   minrust:
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,10 @@ categories = ["memory-management", "data-structures", "no_std"]
 [features]
 std = []
 default = ["std"]
+
+[dependencies]
+serde = { version = "1.0.95", optional = true, default-features = false, features = ["alloc"] }
+
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_test = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,11 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate core;
+
+#[cfg(feature = "serde")]
+mod serde;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -112,17 +117,12 @@ use alloc::vec::Vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec;
 
-#[cfg(not(feature = "std"))]
 use core::iter::FromIterator;
 
-#[cfg(not(feature = "std"))]
 use core::{fmt, mem, ops, slice};
 
 #[cfg(feature = "std")]
-use std::iter::FromIterator;
-
-#[cfg(feature = "std")]
-use std::{fmt, mem, ops, slice, vec};
+use std::vec;
 
 /// Pre-allocated storage for a uniform data type
 ///

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,91 @@
+extern crate serde;
+
+use core::fmt;
+use core::marker::PhantomData;
+
+use self::serde::de::{Deserialize, Deserializer, MapAccess, Visitor};
+use self::serde::ser::{Serialize, SerializeMap, Serializer};
+
+use super::{Entry, Slab};
+
+impl<T> Serialize for Slab<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map_serializer = serializer.serialize_map(Some(self.len()))?;
+        for (key, value) in self {
+            map_serializer.serialize_key(&key)?;
+            map_serializer.serialize_value(value)?;
+        }
+        map_serializer.end()
+    }
+}
+
+struct SlabVisitor<T>(PhantomData<T>);
+
+impl<'de, T> Visitor<'de> for SlabVisitor<T>
+where
+    T: Deserialize<'de>,
+{
+    type Value = Slab<T>;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "a map")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut slab = Slab::with_capacity(map.size_hint().unwrap_or(0));
+
+        // same as FromIterator impl
+        let mut vacant_list_broken = false;
+        while let Some((key, value)) = map.next_entry()? {
+            if key < slab.entries.len() {
+                // iterator is not sorted, might need to recreate vacant list
+                if let Entry::Vacant(_) = slab.entries[key] {
+                    vacant_list_broken = true;
+                    slab.len += 1;
+                }
+                // if an element with this key already exists, replace it.
+                // This is consisent with HashMap and BtreeMap
+                slab.entries[key] = Entry::Occupied(value);
+            } else {
+                // insert holes as necessary
+                while slab.entries.len() < key {
+                    // add the entry to the start of the vacant list
+                    let next = slab.next;
+                    slab.next = slab.entries.len();
+                    slab.entries.push(Entry::Vacant(next));
+                }
+                slab.entries.push(Entry::Occupied(value));
+                slab.len += 1;
+            }
+        }
+        if slab.len == slab.entries.len() {
+            // no vacant enries, so next might not have been updated
+            slab.next = slab.entries.len();
+        } else if vacant_list_broken {
+            slab.recreate_vacant_list();
+        }
+
+        Ok(slab)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Slab<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(SlabVisitor(PhantomData))
+    }
+}

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,50 @@
+#![cfg(feature = "serde")]
+
+extern crate serde;
+extern crate serde_test;
+extern crate slab;
+
+use serde::{Deserialize, Serialize};
+use serde_test::{assert_tokens, Token};
+use slab::Slab;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+struct SlabPartialEq<T>(Slab<T>);
+
+impl<T: PartialEq> PartialEq for SlabPartialEq<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0
+            .iter()
+            .zip(other.0.iter())
+            .all(|(this, other)| this.0 == other.0 && this.1 == other.1)
+    }
+}
+
+#[test]
+fn test_serde_empty() {
+    let slab = Slab::<usize>::new();
+    assert_tokens(
+        &SlabPartialEq(slab),
+        &[Token::Map { len: Some(0) }, Token::MapEnd],
+    );
+}
+
+#[test]
+fn test_serde() {
+    let vec = vec![(1, 2), (3, 4), (5, 6)];
+    let slab: Slab<_> = vec.iter().cloned().collect();
+    assert_tokens(
+        &SlabPartialEq(slab),
+        &[
+            Token::Map { len: Some(3) },
+            Token::U64(1),
+            Token::I32(2),
+            Token::U64(3),
+            Token::I32(4),
+            Token::U64(5),
+            Token::I32(6),
+            Token::MapEnd,
+        ],
+    );
+}


### PR DESCRIPTION
Based on the discussion in #70, serialize and deserialize `Slab` as a map (key: `usize`, value: `T`).

Closes #69
Closes #70