### PR TITLE
Remove html_root_url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@
 name = "slab"
 # When releasing to crates.io:
 # - Update version number
-#   - lib.rs: html_root_url.
 #   - README.md
 # - Update CHANGELOG.md
 # - Update doc URL.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/slab/0.4.2")]
 #![warn(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, warn(unreachable_pub))]
 #![cfg_attr(not(feature = "std"), no_std)]


### PR DESCRIPTION
AFAIK, html_root_url is not needed in most cases. And api-guidelines no longer recommends this. See rust-lang/api-guidelines#229 for more.

Related: https://github.com/tokio-rs/tokio/pull/3489