### PR TITLE
Add #[track_caller] attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -965,6 +965,7 @@ impl<T> Slab<T> {
     /// assert_eq!(slab.remove(hello), "hello");
     /// assert!(!slab.contains(hello));
     /// ```
+    #[track_caller]
     pub fn remove(&mut self, key: usize) -> T {
         if let Some(entry) = self.entries.get_mut(key) {
             // Swap the entry at the provided value


### PR DESCRIPTION
Adds a `#[track_caller]` attribute to `remove`, giving a better backtrace when a wrong key is being passed.

I didn't add the attributes to `Index`/`IndexMut` because it seems to work without, although I don't really know why.
