### PR TITLE
Use debug_struct on Slab::debug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1207,12 +1207,10 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            fmt,
-            "Slab {{ len: {}, cap: {} }}",
-            self.len,
-            self.capacity()
-        )
+        fmt.debug_struct("Slab")
+            .field("len", &self.len)
+            .field("cap", &self.capacity())
+            .finish()
     }
 }
 


### PR DESCRIPTION
We already use `debug_struct` for all the objects in this crate apart from `Slab`.