### PR TITLE
Pass --no-dev-deps flag to cargo-hack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: rustup update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - name: Install cargo-hack
         run: cargo install cargo-hack
-      - run: cargo hack build --feature-powerset --optional-deps
+      - run: cargo hack build --feature-powerset --optional-deps --no-dev-deps
       - run: cargo test --all-features
 
   minrust:


### PR DESCRIPTION
https://github.com/taiki-e/cargo-hack#--feature-powerset

> This is useful to check that every combination of features is working properly. (When used for this purpose, it is recommended to use with --no-dev-deps to avoid cargo#4866.)

