### PR TITLE
Remove version from doc URLs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,12 @@ name = "slab"
 # - Update version number
 #   - README.md
 # - Update CHANGELOG.md
-# - Update doc URL.
-#   - Cargo.toml
-#   - README.md
 # - Create git tag
 version = "0.4.3"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Pre-allocated storage for a uniform data type"
-documentation = "https://docs.rs/slab/0.4.3/slab/"
+documentation = "https://docs.rs/slab"
 homepage = "https://github.com/tokio-rs/slab"
 repository = "https://github.com/tokio-rs/slab"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Pre-allocated storage for a uniform data type.
 [ci-badge]: https://img.shields.io/github/workflow/status/tokio-rs/slab/CI/master
 [ci-url]: https://github.com/tokio-rs/slab/actions
 
-[Documentation](https://docs.rs/slab/0.4.3/slab/)
+[Documentation](https://docs.rs/slab)
 
 ## Usage
 


### PR DESCRIPTION
This is not necessary in most cases because docs.rs will redirect to the latest version.