### PR TITLE
Release 0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.4.4 (August 06, 2021)
+
+* Fix panic in `FromIterator` impl (#102)
+* Fix compatibility with older clippy versions (#104)
+* Add `try_remove` method (#89)
+* Implement `ExactSizeIterator` and `FusedIterator` for iterators (#92)
+
 # 0.4.3 (April 20, 2021)
 
 * Add no_std support for Rust 1.36 and above (#71).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "slab"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use `slab`, first add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-slab = "0.4.3"
+slab = "0.4"
 ```
 
 Next, add this to your crate:


### PR DESCRIPTION
awaiting #104 and #105

Changes:

* Fix panic in `FromIterator` impl (#102)
* Fix compatibility with older clippy versions (#104)
* Add `try_remove` method (#89)
* Implement `ExactSizeIterator` and `FusedIterator` for iterators (#92)