### PR TITLE
Add alternate debug output for listing items in the slab

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1253,10 +1253,14 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Slab")
-            .field("len", &self.len)
-            .field("cap", &self.capacity())
-            .finish()
+        if fmt.alternate() {
+            fmt.debug_map().entries(self.iter()).finish()
+        } else {
+            fmt.debug_struct("Slab")
+                .field("len", &self.len)
+                .field("cap", &self.capacity())
+                .finish()
+        }
     }
 }
 


### PR DESCRIPTION
When debugging output of items in a slab (particularly when a slab is nested in another object that can otherwise just `#[derive(Debug)]`), I usually want to see the actual content of the items in the slab, not just its used size and capacity.

I made an assumption that the original debug output was intentionally not written to show items, so I added an alternate output instead of replacing the existing implementation. If this is not desired I can update this PR with one that replaces the existing implementation so items are always shown.

Let me know if you have questions. Thanks!