### PR TITLE
Fix typo in debug output of IntoIter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1265,7 +1265,7 @@ where
     T: fmt::Debug,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Iter")
+        fmt.debug_struct("IntoIter")
             .field("remaining", &self.len)
             .finish()
     }


### PR DESCRIPTION
This is a trivial fix to correct the struct name emitted for an `IntoIter`.