### PR TITLE
Add method to get vacant key without mutable access

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,11 +917,11 @@ impl<T> Slab<T> {
         key
     }
 
-    /// Return a key for a vacant entry.
+    /// Returns the key of the next vacant entry.
     ///
-    /// This function is useful when you need to get the vacant key which
-    /// will be used for next insertion.
-    /// Same as `slab.vacant_entry().key()` but doesn't require mutable access.
+    /// This function returns the key of the vacant entry which  will be used
+    /// for the next insertion. This is equivalent to
+    /// `slab.vacant_entry().key()`, but it doesn't require mutable access.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -917,6 +917,30 @@ impl<T> Slab<T> {
         key
     }
 
+    /// Return a key for a vacant entry.
+    ///
+    /// This function is useful when you need to get the vacant key which
+    /// will be used for next insertion.
+    /// Same as `slab.vacant_entry().key()` but doesn't require mutable access.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slab::*;
+    /// let mut slab = Slab::new();
+    /// assert_eq!(slab.vacant_key(), 0);
+    ///
+    /// slab.insert(0);
+    /// assert_eq!(slab.vacant_key(), 1);
+    ///
+    /// slab.insert(1);
+    /// slab.remove(0);
+    /// assert_eq!(slab.vacant_key(), 0);
+    /// ```
+    pub fn vacant_key(&self) -> usize {
+        self.next
+    }
+
     /// Return a handle to a vacant entry allowing for further manipulation.
     ///
     /// This function is useful when creating values that must contain their


### PR DESCRIPTION
Same as `slab.vacant_entry().key()` without requiring mutable access.