### PR TITLE
Release 0.4.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,19 +5,12 @@ on:
     tags:
       - v[0-9]+.*
 
-env:
-  RUSTFLAGS: -Dwarnings
-  RUST_BACKTRACE: 1
-
 jobs:
   create-release:
     if: github.repository_owner == 'tokio-rs'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust
-        run: rustup update stable
-      - run: cargo package
       - uses: taiki-e/create-gh-release-action@v1
         with:
           changelog: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
+# 0.4.6 (March 27, 2022)
+
+* Add `Slab::vacant_key` (#114)
+* Fix stacked borrows violation in `Slab::get2_unchecked_mut` (#115)
+
 # 0.4.5 (October 13, 2021)
 
- * Add alternate debug output for listing items in the slab (#108)
- * Fix typo in debug output of IntoIter (#109)
- * Impl 'Clone' for 'Iter' (#110)
+* Add alternate debug output for listing items in the slab (#108)
+* Fix typo in debug output of IntoIter (#109)
+* Impl 'Clone' for 'Iter' (#110)
 
 # 0.4.4 (August 06, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.4.6 (March 27, 2022)
+# 0.4.6 (April 2, 2022)
 
 * Add `Slab::vacant_key` (#114)
 * Fix stacked borrows violation in `Slab::get2_unchecked_mut` (#115)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,13 @@ name = "slab"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
+rust-version = "1.31"
 license = "MIT"
 description = "Pre-allocated storage for a uniform data type"
-documentation = "https://docs.rs/slab"
-homepage = "https://github.com/tokio-rs/slab"
 repository = "https://github.com/tokio-rs/slab"
-readme = "README.md"
 keywords = ["slab", "allocator", "no_std"]
 categories = ["memory-management", "data-structures", "no-std"]
 exclude = ["/.*"]


### PR DESCRIPTION
Changes:

* Add `Slab::vacant_key` (#114)
* Fix stacked borrows violation in `Slab::get2_unchecked_mut` (#115)