### PR TITLE
Release 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.7 (July 19, 2022)
+
+* Use `#[track_caller]` on Rust 1.46+ (#119)
+* Make `Slab::new` const on Rust 1.39+ (#119)
+
 # 0.4.6 (April 2, 2022)
 
 * Add `Slab::vacant_key` (#114)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "slab"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 rust-version = "1.31"


### PR DESCRIPTION
Changes:

* Use `#[track_caller]` on Rust 1.46+ (#119)
* Make `Slab::new` const on Rust 1.39+ (#119)