### PR TITLE
Fix clippy::needless_borrowed_reference warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -686,7 +686,7 @@ impl<T> Slab<T> {
     /// ```
     pub fn get(&self, key: usize) -> Option<&T> {
         match self.entries.get(key) {
-            Some(&Entry::Occupied(ref val)) => Some(val),
+            Some(Entry::Occupied(val)) => Some(val),
             _ => None,
         }
     }
@@ -1178,7 +1178,7 @@ impl<T> ops::Index<usize> for Slab<T> {
     #[cfg_attr(not(slab_no_track_caller), track_caller)]
     fn index(&self, key: usize) -> &T {
         match self.entries.get(key) {
-            Some(&Entry::Occupied(ref v)) => v,
+            Some(Entry::Occupied(v)) => v,
             _ => panic!("invalid key"),
         }
     }


### PR DESCRIPTION
Fixes newly added clippy warning.
```
warning: dereferencing a tuple pattern where every element takes a reference
   --> src/lib.rs:689:18
    |
689 |             Some(&Entry::Occupied(ref val)) => Some(val),
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrowed_reference
    = note: `#[warn(clippy::needless_borrowed_reference)]` on by default
help: try removing the `&` and `ref` parts
    |
689 -             Some(&Entry::Occupied(ref val)) => Some(val),
689 +             Some(Entry::Occupied(val)) => Some(val),
    |

warning: dereferencing a tuple pattern where every element takes a reference
    --> src/lib.rs:1181:18
     |
1181 |             Some(&Entry::Occupied(ref v)) => v,
     |                  ^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrowed_reference
help: try removing the `&` and `ref` parts
     |
1181 -             Some(&Entry::Occupied(ref v)) => v,
1181 +             Some(Entry::Occupied(v)) => v,
     |
```