### PR TITLE
Refactor building from pairs

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,63 @@
+use crate::{Entry, Slab};
+
+// Building `Slab` from pairs (usize, T).
+pub(crate) struct Builder<T> {
+    slab: Slab<T>,
+    vacant_list_broken: bool,
+    first_vacant_index: Option<usize>,
+}
+
+impl<T> Builder<T> {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            slab: Slab::with_capacity(capacity),
+            vacant_list_broken: false,
+            first_vacant_index: None,
+        }
+    }
+    pub(crate) fn pair(&mut self, key: usize, value: T) {
+        let slab = &mut self.slab;
+        if key < slab.entries.len() {
+            // iterator is not sorted, might need to recreate vacant list
+            if let Entry::Vacant(_) = slab.entries[key] {
+                self.vacant_list_broken = true;
+                slab.len += 1;
+            }
+            // if an element with this key already exists, replace it.
+            // This is consistent with HashMap and BtreeMap
+            slab.entries[key] = Entry::Occupied(value);
+        } else {
+            if self.first_vacant_index.is_none() && slab.entries.len() < key {
+                self.first_vacant_index = Some(slab.entries.len());
+            }
+            // insert holes as necessary
+            while slab.entries.len() < key {
+                // add the entry to the start of the vacant list
+                let next = slab.next;
+                slab.next = slab.entries.len();
+                slab.entries.push(Entry::Vacant(next));
+            }
+            slab.entries.push(Entry::Occupied(value));
+            slab.len += 1;
+        }
+    }
+
+    pub(crate) fn build(self) -> Slab<T> {
+        let mut slab = self.slab;
+        if slab.len == slab.entries.len() {
+            // no vacant entries, so next might not have been updated
+            slab.next = slab.entries.len();
+        } else if self.vacant_list_broken {
+            slab.recreate_vacant_list();
+        } else if let Some(first_vacant_index) = self.first_vacant_index {
+            let next = slab.entries.len();
+            match &mut slab.entries[first_vacant_index] {
+                Entry::Vacant(n) => *n = next,
+                _ => unreachable!(),
+            }
+        } else {
+            unreachable!()
+        }
+        slab
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ extern crate std as alloc;
 #[cfg(feature = "serde")]
 mod serde;
 
-pub(crate) mod builder;
+mod builder;
 
 use alloc::vec::{self, Vec};
 use core::iter::{self, FromIterator, FusedIterator};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,8 @@ extern crate std as alloc;
 #[cfg(feature = "serde")]
 mod serde;
 
+pub(crate) mod builder;
+
 use alloc::vec::{self, Vec};
 use core::iter::{self, FromIterator, FusedIterator};
 use core::{fmt, mem, ops, slice};
@@ -1260,51 +1262,12 @@ impl<T> FromIterator<(usize, T)> for Slab<T> {
         I: IntoIterator<Item = (usize, T)>,
     {
         let iterator = iterable.into_iter();
-        let mut slab = Self::with_capacity(iterator.size_hint().0);
+        let mut builder = builder::Builder::with_capacity(iterator.size_hint().0);
 
-        let mut vacant_list_broken = false;
-        let mut first_vacant_index = None;
         for (key, value) in iterator {
-            if key < slab.entries.len() {
-                // iterator is not sorted, might need to recreate vacant list
-                if let Entry::Vacant(_) = slab.entries[key] {
-                    vacant_list_broken = true;
-                    slab.len += 1;
-                }
-                // if an element with this key already exists, replace it.
-                // This is consistent with HashMap and BtreeMap
-                slab.entries[key] = Entry::Occupied(value);
-            } else {
-                if first_vacant_index.is_none() && slab.entries.len() < key {
-                    first_vacant_index = Some(slab.entries.len());
-                }
-                // insert holes as necessary
-                while slab.entries.len() < key {
-                    // add the entry to the start of the vacant list
-                    let next = slab.next;
-                    slab.next = slab.entries.len();
-                    slab.entries.push(Entry::Vacant(next));
-                }
-                slab.entries.push(Entry::Occupied(value));
-                slab.len += 1;
-            }
+            builder.pair(key, value)
         }
-        if slab.len == slab.entries.len() {
-            // no vacant entries, so next might not have been updated
-            slab.next = slab.entries.len();
-        } else if vacant_list_broken {
-            slab.recreate_vacant_list();
-        } else if let Some(first_vacant_index) = first_vacant_index {
-            let next = slab.entries.len();
-            match &mut slab.entries[first_vacant_index] {
-                Entry::Vacant(n) => *n = next,
-                _ => unreachable!(),
-            }
-        } else {
-            unreachable!()
-        }
-
-        slab
+        builder.build()
     }
 }
 


### PR DESCRIPTION
Implementations of `FromIterator::from_iter` and `Visitor::visit_map` share a lot of repeated code about building a `Slab` from pairs. This PR extracts it into a `Builder`.