### PR TITLE
Document panic in `get2_mut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -726,6 +726,10 @@ impl<T> Slab<T> {
     /// This function can be used to get two mutable references out of one slab,
     /// so that you can manipulate both of them at the same time, eg. swap them.
     ///
+    /// # Panics
+    ///
+    /// This function will panic if `key1` and `key2` are the same.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
Just figured it was worth having documented, since most of the other potential panics are documented