### PR TITLE
Release v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.4.8 (January 20, 2022)
+
+* Fixed documentation about overflow (#124)
+* Document panic in `get2_mut` (#131)
+* Refactoring (#129, #132)
+
 # 0.4.7 (July 19, 2022)
 
 * Use `#[track_caller]` on Rust 1.46+ (#119)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "slab"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 rust-version = "1.31"


### PR DESCRIPTION
# 0.4.8 (January 20, 2022)

* Fixed documentation about overflow (#124)
* Document panic in `get2_mut` (#131)
* Refactoring (#129, #132)