### PR TITLE
Make Slab::clone_from avoid reallocation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,6 @@ use core::{fmt, mem, ops, slice};
 /// See the [module documentation] for more details.
 ///
 /// [module documentation]: index.html
-#[derive(Clone)]
 pub struct Slab<T> {
     // Chunk of memory
     entries: Vec<Entry<T>>,
@@ -140,6 +139,22 @@ pub struct Slab<T> {
     // Offset of the next available slot in the slab. Set to the slab's
     // capacity when the slab is full.
     next: usize,
+}
+
+impl<T> Clone for Slab<T> where T: Clone {
+    fn clone(&self) -> Self {
+        Self {
+            entries: self.entries.clone(),
+            len: self.len,
+            next: self.next
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.entries.clone_from(&source.entries);
+        self.len = source.len;
+        self.next = source.next;
+    }
 }
 
 impl<T> Default for Slab<T> {

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -710,3 +710,24 @@ fn try_remove() {
 fn const_new() {
     static _SLAB: Slab<()> = Slab::new();
 }
+
+#[test]
+fn clone_from() {
+    let mut slab1 = Slab::new();
+    let mut slab2 = Slab::new();
+    for i in 0..5 {
+        slab1.insert(i);
+        slab2.insert(2 * i);
+        slab2.insert(2 * i + 1);
+    }
+    slab1.remove(1);
+    slab1.remove(3);
+    slab2.clone_from(&slab1);
+
+    let mut iter2 = slab2.iter();
+    assert_eq!(iter2.next(), Some((0, &0)));
+    assert_eq!(iter2.next(), Some((2, &2)));
+    assert_eq!(iter2.next(), Some((4, &4)));
+    assert_eq!(iter2.next(), None);
+    assert!(slab2.capacity() >= 10);
+}


### PR DESCRIPTION
`#[derive(Clone)]` does not automatically implement `clone_from`, [this is a known issue](https://github.com/rust-lang/rust/issues/98374), it seems because of compile times.

However, `clone_from` has a real use when a data structure contains heap-allocated storage, such as `Box`, `Vec`, etc: it avoids making a new memory allocation if the "host" struct has enough space already.

This PR fixes that, removing the `#derive` and implementing Clone manually, avoiding a new allocation when using `Slab::clone_from`.