### PR TITLE
Release v0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.9 (August 22, 2023)
+
+* Avoid reallocations in `Slab::clone_from` (#137)
+
 # 0.4.8 (January 20, 2023)
 
 * Fixed documentation about overflow (#124)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "slab"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.4.8"
+version = "0.4.9"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 rust-version = "1.31"


### PR DESCRIPTION
# 0.4.9 (August 22, 2023)

* Avoid reallocations in `Slab::clone_from` (#137)