### PR TITLE
Implement Extend trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -969,6 +969,21 @@ impl<T> Slab<T> {
         key
     }
 
+    /// Insert values in the slab from an iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use slab::*;
+    /// let mut slab = Slab::with_capacity(5);
+    /// slab.extend(1..9);
+    /// assert_eq!(slab[5], 6);
+    /// assert_eq!(slab.len(), 8);
+    /// ```
+    pub fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) -> Vec<usize> {
+        iter.into_iter().map(|x| self.insert(x)).collect()
+    }
+
     /// Returns the key of the next vacant entry.
     ///
     /// This function returns the key of the vacant entry which  will be used
@@ -1196,14 +1211,6 @@ impl<T> Slab<T> {
         Drain {
             inner: self.entries.drain(..),
             len: old_len,
-        }
-    }
-}
-
-impl<T> Extend<T> for Slab<T> {
-    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        for value in iter.into_iter() {
-            self.insert(value);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1200,6 +1200,14 @@ impl<T> Slab<T> {
     }
 }
 
+impl<T> Extend<T> for Slab<T> {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        for value in iter.into_iter() {
+            self.insert(value);
+        }
+    }
+}
+
 impl<T> ops::Index<usize> for Slab<T> {
     type Output = T;
 

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -77,6 +77,14 @@ fn insert_with_vacant_entry() {
 }
 
 #[test]
+fn extend() {
+    let mut slab = Slab::with_capacity(5);
+    slab.extend(1..9);
+    assert_eq!(slab[5], 6);
+    assert_eq!(slab.len(), 8);
+}
+
+#[test]
 fn get_vacant_entry_without_using() {
     let mut slab = Slab::<usize>::with_capacity(1);
     let key = slab.vacant_entry().key();

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -77,14 +77,6 @@ fn insert_with_vacant_entry() {
 }
 
 #[test]
-fn extend() {
-    let mut slab = Slab::with_capacity(5);
-    slab.extend(1..9);
-    assert_eq!(slab[5], 6);
-    assert_eq!(slab.len(), 8);
-}
-
-#[test]
 fn get_vacant_entry_without_using() {
     let mut slab = Slab::<usize>::with_capacity(1);
     let key = slab.vacant_entry().key();


### PR DESCRIPTION
This PR implements the `Extend` trait by just inserting all of the items in the iterator. I also added a test function for it, but I'm not sure how necessary that is.