### PR TITLE
Always set #![no_std] to fix redundant import warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(
     missing_debug_implementations,
     missing_docs,
@@ -112,6 +112,8 @@
 
 #[cfg(not(feature = "std"))]
 extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
 #[cfg(feature = "std")]
 extern crate std as alloc;
 


### PR DESCRIPTION
https://github.com/tokio-rs/slab/actions/runs/8127091579/job/22211542846

```
error: the item `Vec` is imported redundantly
   --> src/lib.rs:123:24
    |
123 | use alloc::vec::{self, Vec};
    |                        ^^^
    |
   ::: /home/runner/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/prelude/mod.rs:115:13
    |
115 |     pub use super::v1::*;
    |             --------- the item `Vec` is already defined here
    |
    = note: `-D unused-imports` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_imports)]`
```