### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,7 @@
 fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-check-cfg=cfg(slab_no_const_vec_new,slab_no_track_caller)");
+
     let cfg = match autocfg::AutoCfg::new() {
         Ok(cfg) => cfg,
         Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
+#![allow(clippy::incompatible_msrv)] // false positive: https://github.com/rust-lang/rust-clippy/issues/12280
 
 //! Pre-allocated storage for a uniform data type.
 //!


### PR DESCRIPTION
- Fix unexpected_cfgs warning since Rust 1.80: https://blog.rust-lang.org/2024/05/06/check-cfg.html
- Ignore buggy clippy::incompatible_msrv lint (false positive: https://github.com/rust-lang/rust-clippy/issues/12280)
- Automatically cancel all outdated workflows on PR (this is unrelated to the CI failure itself, but helps to reduce frustration in the PR that fixes it.)

For the first and second, see commit messages for the actual warnings.