### PR TITLE
Fix newly added clippy warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,7 +209,7 @@ pub struct Iter<'a, T> {
     len: usize,
 }
 
-impl<'a, T> Clone for Iter<'a, T> {
+impl<T> Clone for Iter<'_, T> {
     fn clone(&self) -> Self {
         Self {
             entries: self.entries.clone(),


### PR DESCRIPTION
Fixes clippy warning added in Rust 1.83.

See commit message for the content of warning.