### PR TITLE
Release v0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* 0.4.10 (June 15, 2025)
+# 0.4.10 (June 15, 2025)
 
 * Add `Slab::get_disjoint_mut` (#149)
 * Drop build script and `autocfg` dependency (#150)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+* 0.4.10 (June 15, 2025)
+
+* Add `Slab::get_disjoint_mut` (#149)
+* Drop build script and `autocfg` dependency (#150)
+* Fix redundant import warning in no_std builds (#143)
+* Fix `clippy::needless_lifetimes` warning (#147)
+* Internal CI improvements (#141, #146)
+
 # 0.4.9 (August 22, 2023)
 
 * Avoid reallocations in `Slab::clone_from` (#137)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "slab"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.4.9"
+version = "0.4.10"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 rust-version = "1.51"


### PR DESCRIPTION
This gets some goodies out after 2 years since the last release.
All changes: https://github.com/tokio-rs/slab/compare/b709dcf8f0884f2e041aa6a6cb4cf54200aa5491...f801afe5cb2379b0178173758273a95f64510527. MSRV went from v1.31 to v1.51, but I guess it's fine given how old 1.51 is and also the cargo version aware resolver?

# Changelog

* Add `Slab::get_disjoint_mut` (#149)
* Drop build script and `autocfg` dependency (#150)
* Fix redundant import warning in no_std builds (#143)
* Fix `clippy::needless_lifetimes` warning (#147)
* Internal CI improvements (#141, #146)