### PR TITLE
Fix `get_disjoint_mut` error condition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,13 +823,14 @@ impl<T> Slab<T> {
         }
 
         let entries_ptr = self.entries.as_mut_ptr();
-        let entries_cap = self.entries.capacity();
+        let entries_len = self.entries.len();
 
         let mut res = MaybeUninit::<[&mut T; N]>::uninit();
         let res_ptr = res.as_mut_ptr() as *mut &mut T;
 
         for (i, &key) in keys.iter().enumerate() {
-            if key >= entries_cap {
+            // `key` won't be greater than `entries_len`.
+            if key >= entries_len {
                 return Err(GetDisjointMutError::IndexOutOfBounds);
             }
             // SAFETY: we made sure above that this key is in bounds.

--- a/tests/slab.rs
+++ b/tests/slab.rs
@@ -767,3 +767,16 @@ fn get_disjoint_mut() {
     assert_eq!(slab[0], 4);
     assert_eq!(slab[4], 0);
 }
+
+#[test]
+fn get_disjoint_mut_out_of_bounds_index_error() {
+    let mut slab: Slab<i32> = Slab::with_capacity(10);
+    slab.insert(1);
+    slab.insert(2);
+
+    // Index 0 and 1 are valid, but index 5 is out of bounds (beyond len)
+    assert_eq!(
+        slab.get_disjoint_mut([0, 1, 5]),
+        Err(GetDisjointMutError::IndexOutOfBounds)
+    );
+}


### PR DESCRIPTION
Fix the condition that triggers `GetDisjointMutError::IndexOutOfBounds`.