### PR TITLE
Release v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.11 (August 8, 2025)
+
+* Fix `Slab::get_disjoint_mut` out of bounds (#152)
+
 # 0.4.10 (June 15, 2025)
 
 * Add `Slab::get_disjoint_mut` (#149)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "slab"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.4.10"
+version = "0.4.11"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 rust-version = "1.51"


### PR DESCRIPTION
# 0.4.11 (August 8, 2025)

* Fix `Slab::get_disjoint_mut` out of bounds (#152)