### PR TITLE
Help the compiler elide copies in try_remove()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,13 +29,13 @@
 //!
 //! # Performance notes
 //!
-//! Methods that remove values and return them, such as `remove()` and
-//! `try_remove()`, might copy the values to the stack even if the returned
-//! values are unused. For types that don't have drop glue, the compiler can
-//! usually elide these copies.
+//! Methods that remove values and return them, such as [`Slab::remove`] and
+//! [`Slab::try_remove`], might copy the removed values to the stack even if
+//! their return values are unused. For types that don't have drop glue, the
+//! compiler can usually elide these copies.
 //!
-//! For types that need drop logic, you may be able to avoid copies by
-//! wrapping with `std::mem::ManuallyDrop` and carefully dropping values
+//! For types that need drop logic, copies during removals may be avoidable
+//! by wrapping with [`std::mem::ManuallyDrop`] and carefully dropping values
 //! in-place prior to removal.
 //!
 //! # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,6 @@
 //! their return values are unused. For types that don't have drop glue, the
 //! compiler can usually elide these copies.
 //!
-//! For types that need drop logic, copies during removals may be avoidable
-//! by wrapping with [`std::mem::ManuallyDrop`] and carefully dropping values
-//! in-place prior to removal.
-//!
 //! # Examples
 //!
 //! Basic storing and retrieval.
@@ -1130,6 +1126,8 @@ impl<T> Slab<T> {
                 self.len -= 1;
                 let prev = std::mem::replace(entry, Entry::Vacant(self.next));
                 self.next = key;
+
+                // the entry was confirmed occupied above
                 match prev {
                     Entry::Occupied(val) => return val.into(),
                     _ => unreachable!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1129,7 +1129,7 @@ impl<T> Slab<T> {
                 // able to elide copying the bytes to the stack if the value
                 // turns out to be unused.
 
-                let val = match std::mem::replace(entry, Entry::Vacant(self.next)) {
+                let val = match core::mem::replace(entry, Entry::Vacant(self.next)) {
                     Entry::Occupied(val) => val, // confirmed occupied above
                     _ => unreachable!(),
                 };


### PR DESCRIPTION
Partially fixes #159.