### PR TITLE
Release v0.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.12 (January 31, 2026)
+
+* Help the compiler elide copies in `try_remove()` (#160)
+* Add security policy (#154)
+
 # 0.4.11 (August 8, 2025)
 
 * Fix `Slab::get_disjoint_mut` out of bounds (#152)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "slab"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.4.11"
+version = "0.4.12"
 authors = ["Carl Lerche <me@carllerche.com>"]
 edition = "2018"
 rust-version = "1.51"


### PR DESCRIPTION
# 0.4.12 (January 31, 2026)

* Help the compiler elide copies in `try_remove()` (#160)
* Add security policy (#154)